### PR TITLE
[feature/#21] 인스턴스 조회 페이지 구현 및 styled-components 적용

### DIFF
--- a/src/app/instance/page.tsx
+++ b/src/app/instance/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import styled from "styled-components";
+import FederationList from "@/components/federations/FederationList";
 
 export default function Instance() {
   return (
     <Container>
       <Content>
         <Title>인스턴스 리스트 조회</Title>
+        <FederationList />
       </Content>
     </Container>
   )

--- a/src/app/supabase/dashboard/page.tsx
+++ b/src/app/supabase/dashboard/page.tsx
@@ -3,25 +3,22 @@
 import styled from "styled-components";
 import MeInfo from '@/components/MeInfo'
 import FederationView from "@/components/federations/FederationView";
-import FederationList from "@/components/federations/FederationList";
 
 export default function Home() {
   return (
     <Container>
       <Title>대시보드</Title>
-      <FederationList />
+      <MeInfo />
+      <FederationView />
     </Container>
   )
 }
 
-{/* <MeInfo />
-      <FederationView /> */}
-
 const Container = styled.div`
   width: 100%;
   margin: 0 auto;
-  text-align: center;
   padding: 2rem 2rem;
+  background-color: gray;
   `
 
 const Title = styled.h1`
@@ -29,5 +26,5 @@ const Title = styled.h1`
   font-weight: 700;
   color: #111827;
   text-align: center;
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 `

--- a/src/components/federations/FederationList.css
+++ b/src/components/federations/FederationList.css
@@ -40,6 +40,8 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
 .action-button {
@@ -57,6 +59,14 @@
 
 .action-button:hover {
   background-color: #520b93;
+}
+
+.blue-hover {
+  background-color: #2563eb;
+}
+
+.blue-hover:hover {
+  background-color: #1e40af;
 }
 
 .create-button {

--- a/src/components/federations/FederationList.tsx
+++ b/src/components/federations/FederationList.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import '../common/FedForm.css'
-import './FederationList.css' // ✅ CSS 분리된 파일 불러오기
+import './FederationList.css'
 
 interface Instance {
   name: string
@@ -49,10 +49,10 @@ export default function FederationList() {
       <table className="instance-table">
         <thead>
           <tr>
-            <th>name</th>
+            <th>Name</th>
             <th>IpAddress</th>
-            <th>port</th>
-            <th>삭제</th>
+            <th>Port</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -63,6 +63,7 @@ export default function FederationList() {
               <td className="instance-port">{instance.port}</td>
               <td>
                 <div className="instance-actions">
+                  <button className="action-button blue-hover">갱신</button>
                   <button className="action-button">삭제</button>
                 </div>
               </td>


### PR DESCRIPTION
## **🧩 ISSUE**

- closed #21, #22

## **❗ WORK DESCRIPTION**

- 사용자가 소유한 인스턴스 조회 화면을 구현했습니다.
- 하단의 '추가하기' 버튼을 누르면 인스턴스 생성 화면으로 이동합니다. 

## **📸 SCREENSHOT**
<!---- <video src="" width="300" /> -->
<!---- <img src="" width="300" /> -->
<img width="1887" height="797" alt="image" src="https://github.com/user-attachments/assets/fdbe0a3c-fa5c-4c74-8d87-fc5fef8db21a" />
  <img src="" width="300" /> | <img src="" width="300" >-->

## **💻 주요 코드**

- FederationList.tsx와 css 파일을 만들어서 화면을 구현했습니다.
- 백엔드로부터 GET 요청을 받아 응답이 있으면 데이터를 출력하고, API 응답이 없을 시 더미데이터를 출력합니다.
- name: string, ip_address: string, port: number로 받아오도록 했습니다.
- next.config.ts 파일에 'styledComponents: true'를 추가함으로써  새로고침 후 styled-components가 미적용되는 에러를 해결했습니다.

## **📢 TO REVIEWERS**

- 대시보드 페이지에서 사용자 정보 출력하는 'MeInfo'는 일단 주석 처리 해두었습니다!