### PR TITLE
[chore/#44] 내 연합의 참여자 조회에 rpc를 통한 username(email) 조인 로직 추가

### DIFF
--- a/src/app/api/federation/participations/route.ts
+++ b/src/app/api/federation/participations/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: Request) {
 
     // 연합 있을 때
     if (fed) {
-        const { data, error } = await supabase.from("participations").select('id, customer_id, instance_id').eq('federation_id', fed.id);
+        const { data, error } = await supabase.rpc('get_customer_with_email', { federation_uuid: fed.id });
         if (error) {
             console.log(error.message);
             return NextResponse.json({ error: "연합의 참여 정보 조회에 실패했습니다." }, { status: 400 });


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🧩 ISSUE**

- closed #44

## **❗ WORK DESCRIPTION**

- "내 연합의 참여자 조회 API 응답"에 대한 피드백 반영

## **📸 SCREENSHOT**

<!---- <video src="" width="300" /> -->
<!---- <img src="" width="300" /> -->
<!----Before | After
  :--: | :--:
  <img src="" width="300" /> | <img src="" width="300" >-->

## **💻 주요 코드**

- DB 테이블에 대한 리스트 응답의 각 컬럼이 {id, customer_id, instance_id} 의 필드로 반환되어 활용이 어려운 점을 피드백
- 세 번째 위치에 username을 추가하여 {id, customer_id, username, instance_id} 의 필드 타입으로 반환하도록 수정
- username은 실제론 회원 가입 당시의 이메일 주소이고, 사전 명시대로 username 식별자로 반환하였음 (기존 필드명: users.email)
